### PR TITLE
Removed dependencies for prerelease versions.

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,35 +24,33 @@
     <PackageVersion Include="AnsiCodes" Version="0.2.1" />
     <PackageVersion Include="Microsoft.Bcl.HashCode" Version="6.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.14.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="4.14.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.14.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.14.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" Version="1.1.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.14.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="4.14.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.Features" Version="4.14.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.SourceGenerators.Testing" Version="1.1.2" />
     <PackageVersion Include="Basic.Reference.Assemblies.Net80" Version="1.8.3" />
     <PackageVersion Include="PolySharp" Version="1.15.0" />
     <PackageVersion Include="System.Buffers" Version="4.6.1" />
-    <PackageVersion Include="System.Collections.Immutable" Version="9.0.10" />
+    <PackageVersion Include="System.Collections.Immutable" Version="10.0.0" />
     <PackageVersion Include="System.Memory" Version="4.5.5" />
-
-    <!-- Currently, only in preview -->
-    <PackageVersion Include="System.CommandLine" Version="2.0.0-rc.2.25502.107" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.0" />
 
     <!-- Security vulnerability overrides -->
     <!-- https://github.com/dotnet/roslyn-sdk/issues/1191 -->
     <PackageVersion Include="System.Formats.Asn1" Version="10.0.0" />
+
     <!-- https://github.com/advisories/GHSA-7jgj-8wvc-jh57 -->
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
+
     <!-- https://github.com/advisories/GHSA-cmhx-cq75-c4mj -->
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
 
-      <!-- Common packages for solution -->
+    <!-- Common packages for solution -->
     <PackageVersion Include="System.Linq.Async" Version="6.0.3" />
-    <PackageVersion Include="Ubiquity.NET.LibLLVM" Version="20.1.8" />
-    <PackageVersion Include="Ubiquity.NET.Versioning" Version="6.0.2-beta" />
     <PackageVersion Include="Antlr4BuildTasks" Version="12.11.0" />
     <PackageVersion Include="Antlr4.Runtime.Standard" Version="4.13.1" />
     <PackageVersion Include="OpenSoftware.DgmlBuilder" Version="2.1.0" />

--- a/IgnoredWords.dic
+++ b/IgnoredWords.dic
@@ -160,6 +160,7 @@ servable
 shaders
 Silverlight
 sizeof
+snupkg
 Sparc
 src
 Stateful

--- a/docfx/antlr-utils/toc.yml
+++ b/docfx/antlr-utils/toc.yml
@@ -1,4 +1,4 @@
-# TOC (Left nav) for antly-utils folder
+# TOC (Left nav) for antlr-utils folder
 - name: Overview
   href: index.md
 - name: Namespaces

--- a/src/Ubiquity.NET.CodeAnalysis.Utils/Ubiquity.NET.CodeAnalysis.Utils.csproj
+++ b/src/Ubiquity.NET.CodeAnalysis.Utils/Ubiquity.NET.CodeAnalysis.Utils.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
     <!--
-      Most runtime support required is polyfilled with additional dependencies. Though
+      Most runtime support required is poly filled with additional dependencies. Though
       some language features have a hard requirement on runtime support not available
       in .NET Standard 2.0 needed for source generators. Thus will land in build errors
       in most cases, but sometimes can end up as runtime errors! BEWARE!
@@ -17,7 +17,7 @@
     <Authors>.NET Foundation,Ubiquity.NET</Authors>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Description>General use .NET extensions and utilities for implementing Roslyn analyzers, fixers and src generators</Description>
-    <PackageTags>Extensions, Rolsyn,Utility,Helper,.NET,Ubiquity.NET</PackageTags>
+    <PackageTags>Extensions, Roslyn,Utility,Helper,.NET,Ubiquity.NET</PackageTags>
     <PackageReadmeFile>ReadMe.md</PackageReadmeFile>
     <PackageProjectUrl>https://github.com/UbiquityDotNET/Ubiquity.NET.Utils</PackageProjectUrl>
     <RepositoryUrl>https://github.com/UbiquityDotNET/Ubiquity.NET.Utils.git</RepositoryUrl>

--- a/src/Ubiquity.NET.SourceGenerator.Test.Utils/Ubiquity.NET.SourceGenerator.Test.Utils.csproj
+++ b/src/Ubiquity.NET.SourceGenerator.Test.Utils/Ubiquity.NET.SourceGenerator.Test.Utils.csproj
@@ -10,7 +10,7 @@
     <Authors>.NET Foundation,Ubiquity.NET</Authors>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Description>General use .NET extensions and utilities for testing Roslyn analyzers, fixers and source generators</Description>
-    <PackageTags>Extensions, Rolsyn, Utility, Helper, .NET, Ubiquity.NET</PackageTags>
+    <PackageTags>Extensions, Roslyn, Utility, Helper, .NET, Ubiquity.NET</PackageTags>
     <PackageReadmeFile>ReadMe.md</PackageReadmeFile>
     <PackageProjectUrl>https://github.com/UbiquityDotNET/Ubiquity.NET.Utils</PackageProjectUrl>
     <RepositoryUrl>https://github.com/UbiquityDotNET/Ubiquity.NET.Utils.git</RepositoryUrl>
@@ -25,9 +25,12 @@
     <PackageReference Include="Microsoft.CodeAnalysis" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" />
+
+    <!-- explicit reference to workaround vulnerability problem -->
+    <PackageReference Include="System.Formats.Asn1" />
   </ItemGroup>
 
-    <ItemGroup>
-        <None Include="ReadMe.md" Pack="true" PackagePath="\" />
-    </ItemGroup>
+  <ItemGroup>
+    <None Include="ReadMe.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Removed dependencies for prerelease versions.
* This allows a final release on NuGet as it won't allow releases to have a dependency on a non-release version
* Minor corrections to spelling