### PR TITLE
Convert to LangVersion 12 as max supported for .NET 8.0

### DIFF
--- a/src/Ubiquity.NET.ANTLR.Utils/Ubiquity.NET.ANTLR.Utils.csproj
+++ b/src/Ubiquity.NET.ANTLR.Utils/Ubiquity.NET.ANTLR.Utils.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
-        <LangVersion>13</LangVersion>
         <Nullable>enable</Nullable>
         <IsAotCompatible>True</IsAotCompatible>
         <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/Ubiquity.NET.CodeAnalysis.Utils/DiagnosticInfo.cs
+++ b/src/Ubiquity.NET.CodeAnalysis.Utils/DiagnosticInfo.cs
@@ -13,11 +13,28 @@ namespace Ubiquity.NET.CodeAnalysis.Utils
     /// </remarks>
     public sealed record DiagnosticInfo
     {
+#if !NET9_0_OR_GREATER
+        /// <summary>Initializes a new instance of the <see cref="DiagnosticInfo"/> class.</summary>
+        /// <param name="descriptor">Descriptor for the diagnostic</param>
+        /// <param name="location">Location in the source file that triggered this diagnostic</param>
+        /// <param name="msgArgs">Args for the message</param>
+        public DiagnosticInfo(DiagnosticDescriptor descriptor, Location? location, params string[] msgArgs)
+            : this(descriptor, location, (IEnumerable<string>)msgArgs)
+        {
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="DiagnosticInfo"/> class.</summary>
+        /// <param name="descriptor">Descriptor for the diagnostic</param>
+        /// <param name="location">Location in the source file that triggered this diagnostic</param>
+        /// <param name="msgArgs">Args for the message</param>
+        public DiagnosticInfo(DiagnosticDescriptor descriptor, Location? location, IEnumerable<string> msgArgs)
+#else
         /// <summary>Initializes a new instance of the <see cref="DiagnosticInfo"/> class.</summary>
         /// <param name="descriptor">Descriptor for the diagnostic</param>
         /// <param name="location">Location in the source file that triggered this diagnostic</param>
         /// <param name="msgArgs">Args for the message</param>
         public DiagnosticInfo(DiagnosticDescriptor descriptor, Location? location, params IEnumerable<string> msgArgs)
+#endif
         {
             Descriptor = descriptor;
             Location = location;

--- a/src/Ubiquity.NET.CodeAnalysis.Utils/NestedClassName.cs
+++ b/src/Ubiquity.NET.CodeAnalysis.Utils/NestedClassName.cs
@@ -11,6 +11,30 @@ namespace Ubiquity.NET.CodeAnalysis.Utils
     public sealed class NestedClassName
         : IEquatable<NestedClassName>
     {
+#if !NET9_0_OR_GREATER
+        /// <summary>Initializes a new instance of the <see cref="NestedClassName"/> class.</summary>
+        /// <param name="keyword">Keyword for this declaration</param>
+        /// <param name="name">Name of the type</param>
+        /// <param name="constraints">Constraints for this type</param>
+        /// <param name="children">Names of any nested child types to form hierarchies</param>
+        /// <remarks>
+        /// <paramref name="keyword"/> is normally one of ("class", "struct", "interface", "record [class|struct]?").
+        /// </remarks>
+        public NestedClassName(string keyword, string name, string constraints, params NestedClassName[] children)
+            : this( keyword, name, constraints, (IEnumerable<NestedClassName>)children)
+        {
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="NestedClassName"/> class.</summary>
+        /// <param name="keyword">Keyword for this declaration</param>
+        /// <param name="name">Name of the type</param>
+        /// <param name="constraints">Constraints for this type</param>
+        /// <param name="children">Names of any nested child types to form hierarchies</param>
+        /// <remarks>
+        /// <paramref name="keyword"/> is normally one of ("class", "struct", "interface", "record [class|struct]?").
+        /// </remarks>
+        public NestedClassName(string keyword, string name, string constraints, IEnumerable<NestedClassName> children)
+#else
         /// <summary>Initializes a new instance of the <see cref="NestedClassName"/> class.</summary>
         /// <param name="keyword">Keyword for this declaration</param>
         /// <param name="name">Name of the type</param>
@@ -20,6 +44,7 @@ namespace Ubiquity.NET.CodeAnalysis.Utils
         /// <paramref name="keyword"/> is normally one of ("class", "struct", "interface", "record [class|struct]?").
         /// </remarks>
         public NestedClassName(string keyword, string name, string constraints, params IEnumerable<NestedClassName> children)
+#endif
         {
             Keyword = keyword;
             Name = name;

--- a/src/Ubiquity.NET.CodeAnalysis.Utils/Result.cs
+++ b/src/Ubiquity.NET.CodeAnalysis.Utils/Result.cs
@@ -29,9 +29,23 @@ namespace Ubiquity.NET.CodeAnalysis.Utils
         {
         }
 
+#if !NET9_0_OR_GREATER
+        /// <summary>Initializes a new instance of the <see cref="Result{T}"/> struct from diagnostics</summary>
+        /// <param name="diagnostics">Information describing the diagnostics for this result</param>
+        public Result(params DiagnosticInfo[] diagnostics)
+            : this((IEnumerable<DiagnosticInfo>)diagnostics)
+        {
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="Result{T}"/> struct from diagnostics</summary>
+        /// <param name="diagnostics">Information describing the diagnostics for this result</param>
+        public Result(IEnumerable<DiagnosticInfo> diagnostics)
+
+#else
         /// <summary>Initializes a new instance of the <see cref="Result{T}"/> struct from diagnostics</summary>
         /// <param name="diagnostics">Information describing the diagnostics for this result</param>
         public Result(params IEnumerable<DiagnosticInfo> diagnostics)
+#endif
             : this(default, [.. diagnostics])
         {
         }

--- a/src/Ubiquity.NET.CodeAnalysis.Utils/Ubiquity.NET.CodeAnalysis.Utils.csproj
+++ b/src/Ubiquity.NET.CodeAnalysis.Utils/Ubiquity.NET.CodeAnalysis.Utils.csproj
@@ -8,8 +8,11 @@
       some language features have a hard requirement on runtime support not available
       in .NET Standard 2.0 needed for source generators. Thus will land in build errors
       in most cases, but sometimes can end up as runtime errors! BEWARE!
+      This sets the language version to the maximum for the supported max target framework
+      specified in global.json. Functionality is Poly Filled, if possible, or conditionally
+      compiled out.
     -->
-    <LangVersion>13</LangVersion>
+    <LangVersion>12</LangVersion>
 
     <!--NuGet packaging support -->
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Ubiquity.NET.CommandLine/DiagnosticReporterExtensions.cs
+++ b/src/Ubiquity.NET.CommandLine/DiagnosticReporterExtensions.cs
@@ -179,10 +179,17 @@ namespace Ubiquity.NET.CommandLine
             Report(self, level, null, location, fmt, args);
         }
 
+#if NET9_0_OR_GREATER
         /// <summary>Reports multiple diagnostics to the reporter</summary>
         /// <param name="self">Reporter to report the diagnostics to</param>
         /// <param name="diagnostics">DIagnostics to report. This is a 'params' value so it is variadic in languages that support such a thing</param>
         public static void Report( this IDiagnosticReporter self, params IEnumerable<DiagnosticMessage> diagnostics )
+#else
+        /// <summary>Reports multiple diagnostics to the reporter</summary>
+        /// <param name="self">Reporter to report the diagnostics to</param>
+        /// <param name="diagnostics">Diagnostics to report.</param>
+        public static void Report( this IDiagnosticReporter self, IEnumerable<DiagnosticMessage> diagnostics )
+#endif
         {
             foreach(var dm in diagnostics)
             {

--- a/src/Ubiquity.NET.CommandLine/Ubiquity.NET.CommandLine.csproj
+++ b/src/Ubiquity.NET.CommandLine/Ubiquity.NET.CommandLine.csproj
@@ -3,7 +3,6 @@
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
-        <LangVersion>13</LangVersion>
         <GenerateDocumentationFile>True</GenerateDocumentationFile>
 
         <!--NuGet packaging support -->

--- a/src/Ubiquity.NET.Extensions.UT/Ubiquity.NET.Extensions.UT.csproj
+++ b/src/Ubiquity.NET.Extensions.UT/Ubiquity.NET.Extensions.UT.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFrameworks>net8.0;net481</TargetFrameworks>
-        <LangVersion>13</LangVersion>
+        <LangVersion>12</LangVersion>
         <IsPackable>false</IsPackable>
         <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     </PropertyGroup>

--- a/src/Ubiquity.NET.Extensions/Properties/SR.cs
+++ b/src/Ubiquity.NET.Extensions/Properties/SR.cs
@@ -48,7 +48,16 @@ namespace Ubiquity.NET.Extensions.Properties
             return string.Format( Resources.Culture, fmt, arg0, arg1, arg2 );
         }
 
+#if !NET9_0_OR_GREATER
+        internal static string Format( [NotNull] string resourceName, params object?[] args )
+        {
+            return Format(resourceName, (IEnumerable<object?>)args);
+        }
+
+        internal static string Format( [NotNull] string resourceName, IEnumerable<object?> args )
+#else
         internal static string Format( [NotNull] string resourceName, params IEnumerable<object?> args )
+#endif
         {
 #if NET6_0_OR_GREATER
             ArgumentNullException.ThrowIfNull( resourceName );

--- a/src/Ubiquity.NET.Extensions/Ubiquity.NET.Extensions.csproj
+++ b/src/Ubiquity.NET.Extensions/Ubiquity.NET.Extensions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
-        <LangVersion>13</LangVersion>
+        <LangVersion>12</LangVersion>
         <Nullable>enable</Nullable>
         <GenerateDocumentationFile>True</GenerateDocumentationFile>
         <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/src/Ubiquity.NET.SrcGeneration/Ubiquity.NET.SrcGeneration.csproj
+++ b/src/Ubiquity.NET.SrcGeneration/Ubiquity.NET.SrcGeneration.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
         <PlatformTarget>AnyCPU</PlatformTarget>
-        <LangVersion>13</LangVersion>
+        <LangVersion>12</LangVersion>
         <IsAotCompatible>True</IsAotCompatible>
         <GenerateDocumentationFile>True</GenerateDocumentationFile>
         <AllowUnsafeBlocks>True</AllowUnsafeBlocks>


### PR DESCRIPTION
Many of these projects used `<LangVersion13</LangVersion>` However, that language version is greater than what is supported by the max runtime they are configured to target. This PR converts them to using at most LangVersion 12, supported by .NET8 LTS runtime.

* Ubiquity.NET.CodeAnaysis.Utils is the exception as that is exclusively targeting RoslynExtensions and only supports .NET standard 2.0.
    - It is still set to a max of 12 and the rest is poly filled.

Most of the changes surround use of params collections instead of just arrays. In all such cases an `#if` is used to detect the support for that feature and falls back to a method/constructor using an array that forwards (tail calls) an Enumerator version) IFF the runtime supports that feature is it used. This should have no impact on consumers of this library except that it doesn't lie and won't use features not supported by the language/runtime.