### PR TITLE
Added multiple extensions methods to simplify common use case of an app that has only a single root command.

### DIFF
--- a/src/Ubiquity.NET.CommandLine.UT/CommandLineTests.cs
+++ b/src/Ubiquity.NET.CommandLine.UT/CommandLineTests.cs
@@ -1,7 +1,11 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
+using System;
 using System.CommandLine;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -10,6 +14,8 @@ namespace Ubiquity.NET.CommandLine.UT
     [TestClass]
     public class CommandLineTests
     {
+        public TestContext TestContext { get; set; }
+
         [TestMethod]
         public void CommandLine_parse_with_version_option_only_succeeds( )
         {
@@ -19,8 +25,8 @@ namespace Ubiquity.NET.CommandLine.UT
             Assert.HasCount( 0, result.Errors, "Version alone should not produce errors" );
 
             var versionOption = result.GetVersionOption();
-            Assert.IsNotNull(versionOption);
-            Assert.AreEqual( versionOption.Action, result.Action);
+            Assert.IsNotNull( versionOption );
+            Assert.AreEqual( versionOption.Action, result.Action );
         }
 
         [TestMethod]
@@ -41,6 +47,16 @@ namespace Ubiquity.NET.CommandLine.UT
         }
 
         [TestMethod]
+        public void CommandLine_with_valid_options_succeeds( )
+        {
+            var settings = CreateTestSettings();
+            ParseResult result = ArgsParsing.Parse<TestOptions>(["--option1", "value1"], settings );
+            Assert.HasCount( 0, result.Errors, "Should succeed without errors" );
+            var options = TestOptions.Bind(result);
+            Assert.AreEqual( "value1", options.Option1 );
+        }
+
+        [TestMethod]
         public void CommandLine_with_known_option_and_version_has_errors( )
         {
             var settings = CreateTestSettings();
@@ -49,15 +65,238 @@ namespace Ubiquity.NET.CommandLine.UT
             Assert.HasCount( 1, result.Errors, "Should be one error (--version must be set alone) [Other errors ignored for --version]" );
         }
 
+        // until https://github.com/dotnet/command-line-api/issues/2664 is resolved this will fail
         [TestMethod]
-        [Ignore("https://github.com/dotnet/command-line-api/issues/2664")]
+        [Ignore( "https://github.com/dotnet/command-line-api/issues/2664" )]
         public void CommandLine_with_known_option_requiring_arg_and_version_has_errors( )
         {
             var settings = CreateTestSettings();
             ParseResult result = ArgsParsing.Parse<TestOptions>(["--option1", "--version"], settings );
 
-            // until https://github.com/dotnet/command-line-api/issues/2664 is resolved this will fail
-            Assert.HasCount( 2, result.Errors, "Should be one error (--version must be set alone, missing arg for --option1)" );
+            Assert.HasCount( 2, result.Errors, "Should be two errors ([0]--version must be set alone, [1] missing arg for --option1)" );
+        }
+
+        [TestMethod]
+        public void Extension_BuildRootCommand_succeeds( )
+        {
+            var settings = CreateTestSettings();
+
+#if NET10_0_OR_GREATER
+            // With C# 14 extensions the type of options is known, so more inference is possible
+            var cmd = TestOptions.BuildRootCommand( settings, o => { } );
+            Assert.IsNotNull( cmd );
+
+            cmd = TestOptions.BuildRootCommand( settings, ( o ) => 1 );
+            Assert.IsNotNull( cmd );
+
+            cmd = TestOptions.BuildRootCommand( settings, ( o, ct ) => Task.CompletedTask );
+            Assert.IsNotNull( cmd );
+
+            cmd = TestOptions.BuildRootCommand( settings, ( o, ct ) => Task.FromResult(1) );
+            Assert.IsNotNull( cmd );
+#else
+            var cmd = CommandLineOptions.BuildRootCommand( settings, ( TestOptions o ) => { } );
+            Assert.IsNotNull( cmd );
+
+            cmd = CommandLineOptions.BuildRootCommand( settings, ( TestOptions o ) => 1 );
+            Assert.IsNotNull( cmd );
+
+            cmd = CommandLineOptions.BuildRootCommand( settings, ( TestOptions o, CancellationToken ct ) => Task.CompletedTask );
+            Assert.IsNotNull( cmd );
+
+            cmd = CommandLineOptions.BuildRootCommand( settings, ( TestOptions o, CancellationToken ct ) => Task.FromResult( 1 ) );
+            Assert.IsNotNull( cmd );
+#endif
+        }
+
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+        // Nullability checks is the whole point of this test case
+        [TestMethod]
+        public void Extentions_BuildRootCommand_throws_if_null( )
+        {
+            var settings = CreateTestSettings();
+
+#if NET10_0_OR_GREATER
+            // overload 1
+            var ex = Assert.ThrowsExactly<ArgumentNullException>( ( ) =>_ = TestOptions.BuildRootCommand( null, ( o ) => { }));
+            Assert.AreEqual( "settings", ex.ParamName );
+
+            ex = Assert.ThrowsExactly<ArgumentNullException>( ( ) => _ = TestOptions.BuildRootCommand( settings, (Action<TestOptions>?)null ) );
+            Assert.AreEqual( "action", ex.ParamName );
+
+            // overload 2
+            ex = Assert.ThrowsExactly<ArgumentNullException>( ( ) => _ = TestOptions.BuildRootCommand( null, ( o ) => 1 ) );
+            Assert.AreEqual( "settings", ex.ParamName );
+
+            ex = Assert.ThrowsExactly<ArgumentNullException>( ( ) => _ = TestOptions.BuildRootCommand( settings, (Func<TestOptions, int>?)null ) );
+            Assert.AreEqual( "action", ex.ParamName );
+
+            // overload 3
+            ex = Assert.ThrowsExactly<ArgumentNullException>( ( ) => _ = TestOptions.BuildRootCommand( null, (  o, ct ) => Task.CompletedTask ) );
+            Assert.AreEqual( "settings", ex.ParamName );
+
+            ex = Assert.ThrowsExactly<ArgumentNullException>( ( ) => _ = TestOptions.BuildRootCommand( settings, (Func<TestOptions, CancellationToken, Task>?)null ) );
+            Assert.AreEqual( "action", ex.ParamName );
+
+            // overload 4
+            ex = Assert.ThrowsExactly<ArgumentNullException>( ( ) => _ = TestOptions.BuildRootCommand( null, ( o, ct ) => Task.FromResult( 1 ) ) );
+            Assert.AreEqual( "settings", ex.ParamName );
+
+            ex = Assert.ThrowsExactly<ArgumentNullException>( ( ) => _ = TestOptions.BuildRootCommand( settings, (Func<TestOptions, CancellationToken, Task<int>>?)null ) );
+            Assert.AreEqual( "action", ex.ParamName );
+#else
+
+            // overload 1
+            var ex = Assert.ThrowsExactly<ArgumentNullException>( ( ) =>_ = CommandLineOptions.BuildRootCommand( null, ( TestOptions o ) => { }));
+            Assert.AreEqual( "settings", ex.ParamName );
+
+            ex = Assert.ThrowsExactly<ArgumentNullException>( ( ) => _ = CommandLineOptions.BuildRootCommand( settings, (Action<TestOptions>?)null ) );
+            Assert.AreEqual( "action", ex.ParamName );
+
+            // overload 2
+            ex = Assert.ThrowsExactly<ArgumentNullException>( ( ) => _ = CommandLineOptions.BuildRootCommand( null, ( TestOptions o ) => 1 ) );
+            Assert.AreEqual( "settings", ex.ParamName );
+
+            ex = Assert.ThrowsExactly<ArgumentNullException>( ( ) => _ = CommandLineOptions.BuildRootCommand( settings, (Func<TestOptions, int>?)null ) );
+            Assert.AreEqual( "action", ex.ParamName );
+
+            // overload 3
+            ex = Assert.ThrowsExactly<ArgumentNullException>( ( ) => _ = CommandLineOptions.BuildRootCommand( null, ( TestOptions o, CancellationToken ct ) => Task.CompletedTask ) );
+            Assert.AreEqual( "settings", ex.ParamName );
+
+            ex = Assert.ThrowsExactly<ArgumentNullException>( ( ) => _ = CommandLineOptions.BuildRootCommand( settings, (Func<TestOptions, CancellationToken, Task>?)null ) );
+            Assert.AreEqual( "action", ex.ParamName );
+
+            // overload 4
+            ex = Assert.ThrowsExactly<ArgumentNullException>( ( ) => _ = CommandLineOptions.BuildRootCommand( null, ( TestOptions o, CancellationToken ct ) => Task.FromResult( 1 ) ) );
+            Assert.AreEqual( "settings", ex.ParamName );
+
+            ex = Assert.ThrowsExactly<ArgumentNullException>( ( ) => _ = CommandLineOptions.BuildRootCommand( settings, (Func<TestOptions, CancellationToken, Task<int>>?)null ) );
+            Assert.AreEqual( "action", ex.ParamName );
+#endif
+        }
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+
+        [TestMethod]
+        public void Extensions_ParseAndInvokeResult_invokes_provided_action( )
+        {
+            bool actionCalled = false;
+            var settings = CreateTestSettings();
+            using var stringWriter = new StringWriter();
+            var reporter = new TextWriterReporter( MsgLevel.Error, error: stringWriter, warning: stringWriter, information: stringWriter, verbose: stringWriter );
+
+            string[] testArgs = ["--option1", "value1"];
+
+#if NET10_0_OR_GREATER
+            Assert.Inconclusive("Not yet implemented for .NET 10/C# 14");
+#else
+            // Overload 1
+            var cmd = CommandLineOptions.BuildRootCommand( settings, ( TestOptions o ) => actionCalled = true);
+            Assert.IsNotNull( cmd );
+            int exitCode = cmd.ParseAndInvokeResult( reporter, settings, testArgs );
+            Assert.IsTrue( actionCalled );
+            Assert.AreEqual( 0, exitCode );
+
+            // Overload 2
+            cmd = CommandLineOptions.BuildRootCommand( settings, ( TestOptions o ) =>
+            {
+                actionCalled = true;
+                return 1;
+            } );
+            Assert.IsNotNull( cmd );
+
+            actionCalled = false;
+            exitCode = cmd.ParseAndInvokeResult( reporter, settings, testArgs);
+            Assert.IsTrue( actionCalled );
+            Assert.AreEqual( 1, exitCode );
+
+            // Overload 3
+            cmd = CommandLineOptions.BuildRootCommand( settings, ( TestOptions o, CancellationToken ct ) =>
+            {
+                actionCalled = true;
+                return Task.CompletedTask;
+            });
+            Assert.IsNotNull( cmd );
+
+            actionCalled = false;
+            exitCode = cmd.ParseAndInvokeResult( reporter, settings, testArgs);
+            Assert.IsTrue( actionCalled );
+            Assert.AreEqual( 0, exitCode );
+
+            // Overload 4
+            cmd = CommandLineOptions.BuildRootCommand( settings, ( TestOptions o, CancellationToken ct ) =>
+            {
+                actionCalled = true;
+                return Task.FromResult( 1 );
+            });
+
+            Assert.IsNotNull( cmd );
+            actionCalled = false;
+            exitCode = cmd.ParseAndInvokeResult( reporter, settings, testArgs);
+            Assert.IsTrue( actionCalled );
+            Assert.AreEqual( 1, exitCode );
+#endif
+        }
+
+        [TestMethod]
+        public async Task Extensions_ParseAndInvokeResultAsync_invokes_provided_action( )
+        {
+            bool actionCalled = false;
+            var settings = CreateTestSettings();
+            using var stringWriter = new StringWriter();
+            var reporter = new TextWriterReporter( MsgLevel.Error, error: stringWriter, warning: stringWriter, information: stringWriter, verbose: stringWriter );
+
+            string[] testArgs = ["--option1", "value1"];
+
+#if NET10_0_OR_GREATER
+            Assert.Inconclusive("Not yet implemented for .NET 10/C# 14");
+#else
+            // Overload 1
+            var cmd = CommandLineOptions.BuildRootCommand( settings, ( TestOptions o ) => actionCalled = true);
+            Assert.IsNotNull( cmd );
+            int exitCode = await cmd.ParseAndInvokeResultAsync( reporter, settings, TestContext.CancellationToken, testArgs );
+            Assert.IsTrue( actionCalled );
+            Assert.AreEqual( 0, exitCode );
+
+            // Overload 2
+            cmd = CommandLineOptions.BuildRootCommand( settings, ( TestOptions o ) =>
+            {
+                actionCalled = true;
+                return 1;
+            } );
+            Assert.IsNotNull( cmd );
+
+            actionCalled = false;
+            exitCode = await cmd.ParseAndInvokeResultAsync( reporter, settings, TestContext.CancellationToken, testArgs);
+            Assert.IsTrue( actionCalled );
+            Assert.AreEqual( 1, exitCode );
+
+            // Overload 3
+            cmd = CommandLineOptions.BuildRootCommand( settings, ( TestOptions o, CancellationToken ct ) =>
+            {
+                actionCalled = true;
+                return Task.CompletedTask;
+            });
+            Assert.IsNotNull( cmd );
+
+            actionCalled = false;
+            exitCode = await cmd.ParseAndInvokeResultAsync( reporter, settings, TestContext.CancellationToken, testArgs);
+            Assert.IsTrue( actionCalled );
+            Assert.AreEqual( 0, exitCode );
+
+            // Overload 4
+            cmd = CommandLineOptions.BuildRootCommand( settings, ( TestOptions o, CancellationToken ct ) =>
+            {
+                actionCalled = true;
+                return Task.FromResult( 1 );
+            });
+
+            Assert.IsNotNull( cmd );
+            actionCalled = false;
+            exitCode = await cmd.ParseAndInvokeResultAsync( reporter, settings, TestContext.CancellationToken, testArgs);
+            Assert.IsTrue( actionCalled );
+            Assert.AreEqual( 1, exitCode );
+#endif
         }
 
         internal static CmdLineSettings CreateTestSettings( DefaultOption defaultOptions = DefaultOption.Help | DefaultOption.Version )

--- a/src/Ubiquity.NET.CommandLine/ColoredConsoleReporter.cs
+++ b/src/Ubiquity.NET.CommandLine/ColoredConsoleReporter.cs
@@ -51,6 +51,7 @@ namespace Ubiquity.NET.CommandLine
             init
             {
                 ArgumentNullException.ThrowIfNull( value );
+
                 ColorMapBackingField = value;
             }
         }

--- a/src/Ubiquity.NET.CommandLine/CommandLineOptions.cs
+++ b/src/Ubiquity.NET.CommandLine/CommandLineOptions.cs
@@ -1,0 +1,121 @@
+﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
+namespace Ubiquity.NET.CommandLine
+{
+    /// <summary>Utility class to host extensions to <see cref="ICommandLineOptions{T}"/></summary>
+    /// <remarks>
+    /// If C# 14 and the `extension` everything feature is supported these will leverage it such that
+    /// the class name is not needed. Otherwise, for older targets the type name is required.
+    /// While default static methods on an interface is allowed, use of them requires explicitly
+    /// using the interface name. Additionally, since the interface is generic, this runs afoul of
+    /// `CA1000: Do not declare static members on generic types`. Thus, this compromise is used to
+    /// at least simplify the usage as much as possible.
+    /// </remarks>
+    public static class CommandLineOptions
+    {
+#if NET10_0_OR_GREATER
+        /// <summary>C# 14 static Extensions for common methods support</summary>
+        /// <typeparam name="T">Type to bind the options to</typeparam>
+        extension<T>( ICommandLineOptions<T> )
+            where T : ICommandLineOptions<T>
+        {
+            /// <summary>Build a root command with handler</summary>
+            /// <param name="settings">Settings to use for the command</param>
+            /// <param name="action">Action to handle the command and returns an exit code</param>
+            /// <returns><see cref="AppControlledDefaultsRootCommand"/> built with <paramref name="action"/> as the handler.</returns>
+            public static AppControlledDefaultsRootCommand BuildRootCommand( CmdLineSettings settings, Func<T, int> action )
+            {
+                var retVal = T.BuildRootCommand(settings);
+                retVal.SetAction( pr => action( T.Bind( pr ) ) );
+                return retVal;
+            }
+
+            public static AppControlledDefaultsRootCommand BuildRootCommand( CmdLineSettings settings, Func<T, CancellationToken, Task<int>> action )
+            {
+                var retVal = T.BuildRootCommand(settings);
+                retVal.SetAction( (pr, ct) => action( T.Bind( pr ), ct ) );
+                return retVal;
+            }
+
+            public static AppControlledDefaultsRootCommand BuildRootCommand( CmdLineSettings settings, Func<T, CancellationToken, Task> action )
+            {
+                var retVal = T.BuildRootCommand(settings);
+                retVal.SetAction( (pr, ct) => action( T.Bind( pr ), ct ) );
+                return retVal;
+            }
+
+            public static AppControlledDefaultsRootCommand BuildRootCommand( CmdLineSettings settings, Action<T> action )
+            {
+                var retVal = T.BuildRootCommand(settings);
+                retVal.SetAction( pr => action( T.Bind( pr ) ) );
+                return retVal;
+            }
+        }
+#else
+        /// <summary>Build a root command with a synchronous handler</summary>
+        /// <typeparam name="T">Type to bind the options to</typeparam>
+        /// <param name="settings">Settings to use for the command</param>
+        /// <param name="action">Action to handle the command and returns an exit code</param>
+        /// <returns><see cref="AppControlledDefaultsRootCommand"/> built with <paramref name="action"/> as the handler.</returns>
+        public static AppControlledDefaultsRootCommand BuildRootCommand<T>( CmdLineSettings settings, Func<T, int> action )
+            where T : ICommandLineOptions<T>
+        {
+            ArgumentNullException.ThrowIfNull(settings);
+            ArgumentNullException.ThrowIfNull(action);
+
+            var retVal = T.BuildRootCommand(settings);
+            retVal.SetAction( pr => action( T.Bind( pr ) ) );
+            return retVal;
+        }
+
+        /// <summary>Build a root command with async handler that returns an application specific exit code (0 == Success/No Error)</summary>
+        /// <typeparam name="T">Type to bind the options to</typeparam>
+        /// <param name="settings">Settings to use for the command</param>
+        /// <param name="action">Async action to handle the command and returns an exit code (via <see cref="Task{TResult}"/>)</param>
+        /// <returns><see cref="AppControlledDefaultsRootCommand"/> built with <paramref name="action"/> as the handler.</returns>
+        public static AppControlledDefaultsRootCommand BuildRootCommand<T>( CmdLineSettings settings, Func<T, CancellationToken, Task<int>> action )
+            where T : ICommandLineOptions<T>
+        {
+            ArgumentNullException.ThrowIfNull(settings);
+            ArgumentNullException.ThrowIfNull(action);
+
+            var retVal = T.BuildRootCommand(settings);
+            retVal.SetAction( (pr, ct) => action( T.Bind( pr ), ct ) );
+            return retVal;
+        }
+
+        /// <summary>Build a root command with async handler</summary>
+        /// <typeparam name="T">Type to bind the options to</typeparam>
+        /// <param name="settings">Settings to use for the command</param>
+        /// <param name="action">Action to handle the command and returns an exit code</param>
+        /// <returns><see cref="AppControlledDefaultsRootCommand"/> built with <paramref name="action"/> as the handler.</returns>
+        public static AppControlledDefaultsRootCommand BuildRootCommand<T>( CmdLineSettings settings, Func<T, CancellationToken, Task> action )
+            where T : ICommandLineOptions<T>
+        {
+            ArgumentNullException.ThrowIfNull(settings);
+            ArgumentNullException.ThrowIfNull(action);
+
+            var retVal = T.BuildRootCommand(settings);
+            retVal.SetAction( (pr, ct) => action( T.Bind( pr ), ct ) );
+            return retVal;
+        }
+
+        /// <summary>Build a root command with a synchronous handler</summary>
+        /// <typeparam name="T">Type to bind the options to</typeparam>
+        /// <param name="settings">Settings to use for the command</param>
+        /// <param name="action">Action to handle the command</param>
+        /// <returns><see cref="AppControlledDefaultsRootCommand"/> built with <paramref name="action"/> as the handler.</returns>
+        public static AppControlledDefaultsRootCommand BuildRootCommand<T>( CmdLineSettings settings, Action<T> action )
+            where T : ICommandLineOptions<T>
+        {
+            ArgumentNullException.ThrowIfNull(settings);
+            ArgumentNullException.ThrowIfNull(action);
+
+            var retVal = T.BuildRootCommand(settings);
+            retVal.SetAction( pr => action( T.Bind( pr ) ) );
+            return retVal;
+        }
+#endif
+    }
+}

--- a/src/Ubiquity.NET.CommandLine/DiagnosticReportingWriter.cs
+++ b/src/Ubiquity.NET.CommandLine/DiagnosticReportingWriter.cs
@@ -1,0 +1,116 @@
+﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
+namespace Ubiquity.NET.CommandLine
+{
+    /// <summary><see cref="TextWriter"/> implementation that wraps an <see cref="IDiagnosticReporter"/></summary>
+    /// <remarks>
+    /// This is an instance of the adapter pattern to provide a text writer interface that wraps an <see cref="IDiagnosticReporter"/>.
+    /// Newlines are detected and transformed into a diagnostic reported to the reporter. This will write a diagnostic
+    /// when <see cref="TextWriter.NewLine"/> is detected. When a diagnostic is reported then the internal builder is cleared so that
+    /// the next line is a new diagnostic. <see cref="MsgLevel"/> is used to specify the message level to report for all
+    /// diagnostics in this writer.
+    /// </remarks>
+    internal class DiagnosticReportingWriter
+        : StringWriter
+    {
+        /// <summary>Initializes a new instance of the <see cref="DiagnosticReportingWriter"/> class.</summary>
+        /// <param name="reporter">Reporter to create reports with</param>
+        /// <param name="msgLevel">Level of diagnostics to report for this instance</param>
+        public DiagnosticReportingWriter( IDiagnosticReporter reporter, MsgLevel msgLevel )
+        {
+            Reporter = reporter;
+            MsgLevel = msgLevel;
+        }
+
+        /// <inheritdoc/>
+        /// <remarks>
+        /// IFF <paramref name="value"/> is <see cref="TextWriter.NewLine"/> then this will
+        /// report the contents of the underlying <see cref="StringBuilder"/> and clear it
+        /// so that any new content is treated as a new diagnostic.
+        /// </remarks>
+        public override void Write( string? value )
+        {
+            if(value is not null && value == NewLine)
+            {
+                ReportContents();
+            }
+            else
+            {
+                base.Write( value );
+            }
+        }
+
+        /// <inheritdoc/>
+        /// <remarks>
+        /// IFF <paramref name="buffer"/> is <see cref="TextWriter.NewLine"/> then this will
+        /// report the contents of the underlying <see cref="StringBuilder"/> and clear it
+        /// so that any new content is treated as a new diagnostic.
+        /// </remarks>
+        public override void Write( char[] buffer, int index, int count )
+        {
+            if(buffer.SequenceEqual( CoreNewLine ))
+            {
+                ReportContents();
+            }
+            else
+            {
+                base.Write( buffer, index, count );
+            }
+        }
+
+        /// <summary>Reports the contents of the underlying builder (if any)</summary>
+        public override void Flush( )
+        {
+            ReportContents();
+        }
+
+        /// <inheritdoc/>
+        public override Task FlushAsync( )
+        {
+            return Task.Factory.StartNew( static state => ((TextWriter)state!).Flush(),
+                                          this,
+                                          CancellationToken.None,
+                                          TaskCreationOptions.DenyChildAttach,
+                                          TaskScheduler.Default
+                                        );
+        }
+
+        /// <inheritdoc/>
+        public override Task FlushAsync( CancellationToken cancellationToken )
+        {
+            return cancellationToken.IsCancellationRequested
+                 ? Task.FromCanceled( cancellationToken )
+                 : FlushAsync();
+        }
+
+        /// <summary>Gets the message level reported by this instance</summary>
+        public MsgLevel MsgLevel { get; }
+
+        /// <summary>Gets the reporter this instance reports diagnostics to</summary>
+        public IDiagnosticReporter Reporter { get; }
+
+        /// <inheritdoc/>
+        protected override void Dispose( bool disposing )
+        {
+            if(disposing)
+            {
+                ReportContents();
+            }
+
+            base.Dispose( disposing );
+        }
+
+        private void ReportContents( )
+        {
+            var bldr = GetStringBuilder();
+            string msg = bldr.ToString();
+            if(!string.IsNullOrWhiteSpace( msg ))
+            {
+                Reporter.Report( MsgLevel, msg );
+            }
+
+            bldr.Clear();
+        }
+    }
+}

--- a/src/Ubiquity.NET.CommandLine/GlobalNamespaceImports.cs
+++ b/src/Ubiquity.NET.CommandLine/GlobalNamespaceImports.cs
@@ -28,6 +28,8 @@ global using System.IO;
 global using System.Linq;
 global using System.Runtime.CompilerServices;
 global using System.Text;
+global using System.Threading;
+global using System.Threading.Tasks;
 
 global using AnsiCodes;
 

--- a/src/Ubiquity.NET.CommandLine/ParseResultExtensions.cs
+++ b/src/Ubiquity.NET.CommandLine/ParseResultExtensions.cs
@@ -45,6 +45,45 @@ namespace Ubiquity.NET.CommandLine
             return versionOptions.FirstOrDefault();
         }
 
+        /// <summary>Invokes the results with re-directing writers that use <paramref name="reporter"/> to write messages</summary>
+        /// <param name="self">Results to invoke</param>
+        /// <param name="reporter">Reporter to report information/errors to</param>
+        /// <param name="ct">Cancellation token to use for the async operation</param>
+        /// <param name="timeout">Timeout for the invocation [Default: null (2s)]</param>
+        /// <returns>Exit code from invoking the results</returns>
+        public static async Task<int> InvokeAsync( this ParseResult self, IDiagnosticReporter reporter, CancellationToken ct, TimeSpan? timeout = null )
+        {
+            using var outWriter = new DiagnosticReportingWriter(reporter, MsgLevel.Information);
+            using var errWriter = new DiagnosticReportingWriter(reporter, MsgLevel.Error);
+            var cfg = new InvocationConfiguration()
+            {
+                Output = outWriter,
+                Error = errWriter,
+                ProcessTerminationTimeout = timeout,
+            };
+
+            return await self.InvokeAsync( cfg, ct );
+        }
+
+        /// <summary>Invokes the results with re-directing writers that use <paramref name="reporter"/> to write messages</summary>
+        /// <param name="self">Results to invoke</param>
+        /// <param name="reporter">Reporter to report information/errors to</param>
+        /// <param name="timeout">Timeout for the invocation [Default: null (2s)]</param>
+        /// <returns>Exit code from invoking the results</returns>
+        public static int Invoke( this ParseResult self, IDiagnosticReporter reporter, TimeSpan? timeout = null )
+        {
+            using var outWriter = new DiagnosticReportingWriter(reporter, MsgLevel.Information);
+            using var errWriter = new DiagnosticReportingWriter(reporter, MsgLevel.Error);
+            var cfg = new InvocationConfiguration()
+            {
+                Output = outWriter,
+                Error = errWriter,
+                ProcessTerminationTimeout = timeout,
+            };
+
+            return self.Invoke( cfg );
+        }
+
         // shamelessly "borrowed" from: https://github.com/dotnet/dotnet/blob/8c7b3dcd2bd657c11b12973f1214e7c3c616b174/src/command-line-api/src/System.CommandLine/Help/HelpBuilderExtensions.cs#L42
         internal static IEnumerable<T> RecurseWhileNotNull<T>( this T? source, Func<T, T?> next )
             where T : class

--- a/src/Ubiquity.NET.CommandLine/RootCommandExtensions.cs
+++ b/src/Ubiquity.NET.CommandLine/RootCommandExtensions.cs
@@ -1,0 +1,93 @@
+﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
+namespace Ubiquity.NET.CommandLine
+{
+    /// <summary>Utility class to provide extensions for <see cref="RootCommand"/> and derived types</summary>
+    public static class RootCommandExtensions
+    {
+        /// <summary>Parses a root command and invokes the results</summary>
+        /// <param name="rootCommand">Command to parse</param>
+        /// <param name="reporter">Diagnostic reporter to use for any errors or information in parsing</param>
+        /// <param name="settings">Settings to use for the parser</param>
+        /// <param name="args">Command line arguments to parse</param>
+        /// <returns>Exit code of the invocation</returns>
+        /// <remarks>
+        /// If the <see cref="Command.Action"/> is an asynchronous command action then this will
+        /// BLOCK the current thread until it completes. If that is NOT the desired behavior then
+        /// callers should use <see cref="ParseAndInvokeResultAsync(RootCommand, IDiagnosticReporter, CmdLineSettings, CancellationToken, string[])"/>
+        /// instead for explicitly async operation.
+        /// </remarks>
+        public static int ParseAndInvokeResult(
+            this RootCommand rootCommand,
+            IDiagnosticReporter reporter,
+            CmdLineSettings settings,
+            params string[] args
+            )
+        {
+            ParseResult parseResult = rootCommand.Parse(args, settings);
+
+            // due to bugs and general design of how the command line handling of help and version commands are
+            // handled this tries the default options BEFORE checking for errors.
+            DefaultHandlerInvocationResult defaultHandlerInvocationResult = parseResult.InvokeDefaultOptions(settings, reporter);
+            if(defaultHandlerInvocationResult.ShouldExit)
+            {
+                return defaultHandlerInvocationResult.ExitCode;
+            }
+
+            // If there are errors process them using settings to control the
+            // output (Nothing else can set these properties. This is the only
+            // known way to configure them)
+            if(parseResult.Action is ParseErrorAction parseErrorAction)
+            {
+                parseErrorAction.ShowHelp = settings.ShowHelpOnErrors;
+                parseErrorAction.ShowTypoCorrections = settings.ShowTypoCorrections;
+            }
+
+            return parseResult.Invoke( reporter );
+        }
+
+        /// <summary>Parses a root command and invokes the results</summary>
+        /// <param name="rootCommand">Command to parse</param>
+        /// <param name="reporter">Diagnostic reporter to use for any errors or information in parsing</param>
+        /// <param name="settings">Settings to use for the parser</param>
+        /// <param name="ct">Cancellation token for the operation</param>
+        /// <param name="args">Command line arguments to parse</param>
+        /// <returns>Exit code of the invocation</returns>
+        public static Task<int> ParseAndInvokeResultAsync(
+            this RootCommand rootCommand,
+            IDiagnosticReporter reporter,
+            CmdLineSettings settings,
+            CancellationToken ct,
+            params string[] args
+            )
+        {
+            return Task.Run( async () =>
+            {
+                ParseResult parseResult = rootCommand.Parse(args, settings);
+                ct.ThrowIfCancellationRequested();
+
+                // due to bugs and general design of how the command line handling of help and version commands are
+                // handled this tries the default options BEFORE checking for errors.
+                DefaultHandlerInvocationResult defaultHandlerInvocationResult = parseResult.InvokeDefaultOptions(settings, reporter);
+                if(defaultHandlerInvocationResult.ShouldExit)
+                {
+                    return defaultHandlerInvocationResult.ExitCode;
+                }
+
+                ct.ThrowIfCancellationRequested();
+
+                // If there are errors process them using settings to control the
+                // output (Nothing else can set these properties. This is the only
+                // known way to configure them)
+                if(parseResult.Action is ParseErrorAction parseErrorAction)
+                {
+                    parseErrorAction.ShowHelp = settings.ShowHelpOnErrors;
+                    parseErrorAction.ShowTypoCorrections = settings.ShowTypoCorrections;
+                }
+
+                return await parseResult.InvokeAsync( reporter, ct );
+            });
+        }
+    }
+}

--- a/src/Ubiquity.NET.PollyFill.SharedSources/PolyFillExceptionValidators.cs
+++ b/src/Ubiquity.NET.PollyFill.SharedSources/PolyFillExceptionValidators.cs
@@ -31,7 +31,7 @@ namespace System
     }
 
     // Sadly, these are NOT localized messages as the official forms are.
-    // There is no way, at least no-known way (easy or not) to inject resources
+    // There is no way, at least no-known way (easy or not), to inject resources
     // that would participate in localization. (If the consumer even does that...)
     // The actual strings used are the same as the values in the official runtime
     // support so are at least compatible for "en-us". This fakes it to make it
@@ -60,13 +60,6 @@ namespace System
     }
 
     /// <summary>poly fill extensions for static methods added in .NET 7</summary>
-    /// <remarks>
-    /// This requires support of the C#14 keyword `extension` to work properly. There is
-    /// no other way to add static methods to non-partial types for source compatibility.
-    /// Otherwise code cannot use the modern .NET runtime implementations and instead
-    /// must always use some extension methods, or litter around a LOT of #if/#else/#endif
-    /// based on the framework version...
-    /// </remarks>
     internal static class PolyFillExceptionValidators
     {
         /// <summary>Throw an <see cref="ArgumentException"/> if a string is <see langword="null"/>m empty, or all whitespace.</summary>

--- a/src/Ubiquity.NET.PollyFill.SharedSources/PolyFillRuntimeHelpersExtensions.cs
+++ b/src/Ubiquity.NET.PollyFill.SharedSources/PolyFillRuntimeHelpersExtensions.cs
@@ -4,6 +4,9 @@
 // Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
+// Sadly, this is not workable as the compiler looks for an explicit static method
+// to support it's generated functionality. It does NOT allow extension methods
+// as older versions of the language don't support such a thing anyway...
 #if COMPILER_LOOKS_FOR_EXTENSIONS
 // based on work from: https://github.com/Sergio0694/PolySharp/issues/104
 

--- a/src/Ubiquity.NET.SrcGeneration.UT/OwningIndentedStringWriter.cs
+++ b/src/Ubiquity.NET.SrcGeneration.UT/OwningIndentedStringWriter.cs
@@ -8,7 +8,6 @@ namespace Ubiquity.NET.SrcGeneration.UT
     // actually moved in such a case - but safe/correct handling of that in general is rather complicated.)
     // In a test scenario, an exception in the constructor will crash the test host and treated as a test
     // failure. This is desired behavior, and extremely unlikely to ever occur, so OK in this special case.
-    [SuppressMessage( "StyleCop.CSharp.MaintainabilityRules", "SA1402:File may only contain a single type", Justification = "DUH, it's file scoped" )]
     [ExcludeFromCodeCoverage]
     internal class OwningIndentedStringWriter
         : IndentedTextWriter


### PR DESCRIPTION
Added multiple extensions methods to simplify common use case of an app that has only a single root command.
* Now defunct project "Dragon Fruit" dealt with this a bit differently but the target scenarios are the same.
* `#if` directives to use .NET 10/C#14
   - Not yet enabled or formally tested but work is present. Later PR will enable support for that.
* Minor formatting fix ups
* Added tests for successful parsing of args.