### PR TITLE
Added generation of `Get[Required]Option` to binder based on the nullability of the type.

### DIFF
--- a/src/Ubiquity.NET.CommandLine.SrcGen.UT/CommandAnalyzerTests.cs
+++ b/src/Ubiquity.NET.CommandLine.SrcGen.UT/CommandAnalyzerTests.cs
@@ -86,6 +86,10 @@ namespace Ubiquity.NET.CommandLine.SrcGen.UT
             await analyzerTest.RunAsync( TestContext.CancellationToken );
         }
 
+        // TODO: Test that a nullable value is not marked as required. (That's a conflicting claim, if it's required it can't be null)
+        //       A nullable type MAY have a default value handler to provide a null default. Additional test - anything with a default
+        //       value provider shouldn't be "required" it's also nonsensical.
+
         private AnalyzerTest<MsTestVerifier> CreateTestRunner( string source, TestRuntime testRuntime )
         {
             return CreateTestRunner( SourceText.From( source ), testRuntime );

--- a/src/Ubiquity.NET.CommandLine.SrcGen.UT/RootCommandAttributeTests.cs
+++ b/src/Ubiquity.NET.CommandLine.SrcGen.UT/RootCommandAttributeTests.cs
@@ -40,11 +40,6 @@ namespace Ubiquity.NET.CommandLine.SrcGen.UT
             await runner.RunAsync( TestContext.CancellationToken );
         }
 
-        // TODO: Test GetOption[Required]Value() for correct behavior
-        //       Nullable types always use GetOptionValue(). // Null is a valid value so it is truly optional.
-        //       non-nullable ref types use GetOptionRequiredValue() // no default is plausible (may provide one using a delegate)
-        //       non-nullable value types use GetOptionValue()       // value types have a default value of 0; (May override with delegate)
-
         private SourceGeneratorTest<MsTestVerifier> CreateTestRunner(
             SourceText source,
             TestRuntime testRuntime,

--- a/src/Ubiquity.NET.CommandLine.SrcGen.UT/TestFiles/RootCommandAttributeTests/Basic_golden_path_succeeds/expected.cs
+++ b/src/Ubiquity.NET.CommandLine.SrcGen.UT/TestFiles/RootCommandAttributeTests/Basic_golden_path_succeeds/expected.cs
@@ -21,10 +21,10 @@ namespace TestNamespace
         {
             return new()
             {
-                SomePath = parseResult.GetValue( Descriptors.SomePath ),
-                SomeExistingPath = parseResult.GetValue( Descriptors.SomeExistingPath ),
+                SomePath = parseResult.GetRequiredValue( Descriptors.SomePath ),
+                SomeExistingPath = parseResult.GetRequiredValue( Descriptors.SomeExistingPath ),
                 Thing1 = parseResult.GetRequiredValue( Descriptors.Thing1 ),
-                SomeOtherPath = parseResult.GetValue( Descriptors.SomeOtherPath ),
+                SomeOtherPath = parseResult.GetRequiredValue( Descriptors.SomeOtherPath ),
             };
         }
 

--- a/src/Ubiquity.NET.CommandLine.SrcGen.UT/TestFiles/RootCommandAttributeTests/Generator_handles_nullable_types/expected.cs
+++ b/src/Ubiquity.NET.CommandLine.SrcGen.UT/TestFiles/RootCommandAttributeTests/Generator_handles_nullable_types/expected.cs
@@ -22,6 +22,7 @@ namespace TestNamespace
             return new()
             {
                 Thing1 = parseResult.GetValue( Descriptors.Thing1 ),
+                Thing2 = parseResult.GetRequiredValue( Descriptors.Thing2 ),
             };
         }
 
@@ -30,6 +31,7 @@ namespace TestNamespace
             return new global::Ubiquity.NET.CommandLine.AppControlledDefaultsRootCommand( Settings, "Root command for tests" )
             {
                 Descriptors.Thing1,
+                Descriptors.Thing2,
             };
         }
     }
@@ -41,6 +43,13 @@ namespace TestNamespace
             {
                 HelpName = "Help name for thing1",
                 Description = "Test Thing1",
+            };
+
+        internal static readonly global::System.CommandLine.Option<bool> Thing2
+            = new global::System.CommandLine.Option<bool>("--thing2", "-t")
+            {
+                HelpName = "Help name for thing2",
+                Description = "Test Thing2",
             };
     }
 }

--- a/src/Ubiquity.NET.CommandLine.SrcGen.UT/TestFiles/RootCommandAttributeTests/Generator_handles_nullable_types/input.cs
+++ b/src/Ubiquity.NET.CommandLine.SrcGen.UT/TestFiles/RootCommandAttributeTests/Generator_handles_nullable_types/input.cs
@@ -7,4 +7,7 @@ internal partial class TestOptions
 {
     [Option( "--thing1", Aliases = [ "-t" ], Description = "Test Thing1", HelpName = "Help name for thing1" )]
     public bool? Thing1 { get; init; }
+
+    [Option( "--thing2", Aliases = [ "-t" ], Description = "Test Thing2", HelpName = "Help name for thing2" )]
+    public bool Thing2 { get; init; }
 }

--- a/src/Ubiquity.NET.CommandLine.SrcGen/Templates/RootCommandClassTemplate.cs
+++ b/src/Ubiquity.NET.CommandLine.SrcGen/Templates/RootCommandClassTemplate.cs
@@ -79,7 +79,7 @@ namespace Ubiquity.NET.CommandLine.SrcGen.Templates
             {
                 foreach (PropertyInfo info in Properties)
                 {
-                    string methodName = info.IsRequired ? "GetRequiredValue" : "GetValue";
+                    string methodName = info.TypeName.IsNullable ? "GetValue" : "GetRequiredValue";
                     writer.WriteLine($"{info.SimpleName} = parseResult.{methodName}( Descriptors.{info.SimpleName} ),");
                 }
             }


### PR DESCRIPTION
Added generation of `Get[Required]Option` to binder based on the nullability of the type.
* Default is to use `GetRequiredOption` and only use `GetOption` when the type is explicitly annotated as nullable.
* Note: The term 'required' as used in those APIs is in the retrieval of the property value and throws an exception if not specified as an argument.
    - Nullable types are by definition possibly null and therefore are not considered "Required"