### PR TITLE
Added test for properties with a nullable type that are marked as required.

### DIFF
--- a/docfx/.editorconfig
+++ b/docfx/.editorconfig
@@ -1,0 +1,34 @@
+#Primary settings apply to all files unless overridden below
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+tab_width = 4
+end_of_line = crlf
+
+# VSSPELL: Spell checker settings for all files
+vsspell_section_id = 869f688c36354e788f0a0b53ab42cf41
+
+# [VSSpellChecker bug 277](https://github.com/EWSoftware/VSSpellChecker/issues/277)
+# VSSPELL: Disable the analyzers until Bug 277 is fixed.
+vsspell_code_analyzers_enabled = false
+vsspell_ignored_words_869f688c36354e788f0a0b53ab42cf41 = File:.\IgnoredWords.dic
+
+# match VS generated formatting for MSBuild project files
+[*.*proj,*.props,*.targets]
+indent_style = space
+indent_size = 2
+tab_width = 2
+
+[*.yml,*.yaml]
+indent_style = space
+indent_size = 2
+tab_width = 2
+
+[*.md]
+# mark left margin for split screen preview of markdown files
+# requires: https://marketplace.visualstudio.com/items?itemName=PaulHarrington.EditorGuidelinesPreview
+guidelines = 92
+

--- a/docfx/CommandLine/Diagnostics/UNC000.md
+++ b/docfx/CommandLine/Diagnostics/UNC000.md
@@ -1,0 +1,6 @@
+# UNC0000: An internal analyzer exception occurred.
+An internal error occurred in the analyzer. Please [report](https://github.com/UbiquityDotNET/Ubiquity.NET.Utils/issues)
+the issue with as much detail as possible, ideally with a small repro to help identify the
+problem. Please include the full stack of the exception as shown in the message details.
+Occurrences of this diagnostic are ALWAYS a bug in the generator/Analyzer in question and
+should be fixed.

--- a/docfx/CommandLine/Diagnostics/UNC001.md
+++ b/docfx/CommandLine/Diagnostics/UNC001.md
@@ -1,0 +1,38 @@
+# UNC001: Missing command attribute on containing type
+A command line property annotating attribute is applied to a property but the containing
+type does not contain an attribute that designates it as a command. The generator will
+***ignore*** the property and the ***entire*** class.
+
+## Example:
+``` C#
+using System.IO;
+
+using Ubiquity.NET.CommandLine.GeneratorAttributes;
+
+namespace TestNamespace;
+
+internal class testInput1
+{
+    [Option( "-o" )] // UNC001 reported here
+    public required DirectoryInfo SomePath { get; init; }
+}
+```
+
+## Fix:
+``` C#
+using System.IO;
+
+using Ubiquity.NET.CommandLine.GeneratorAttributes;
+
+namespace TestNamespace;
+
+// apply a command attribute to the type to allow generation
+// of the backing details for parsing and binding the results to this type.
+[RootCommand( Description = "Root command for tests" )]
+internal class testInput1
+{
+    [Option( "-o" )]
+    public required DirectoryInfo SomePath { get; init; }
+}
+```
+

--- a/docfx/CommandLine/Diagnostics/UNC002.md
+++ b/docfx/CommandLine/Diagnostics/UNC002.md
@@ -1,0 +1,45 @@
+# UNC002 : Property attribute not allowed standalone
+This diagnostic is reported when an attribute is detected that is a qualifier to another
+required attribute, but the required attribute is not present.
+
+## Example
+`FolderValidationAttribute` provides additional information for validation of a property. To
+generate source that operates correctly an additional attribute is required. For example,
+to specify that a Folder provided must exist already a command can apply the
+`FolderValidationAttribute`. However that attribute requires additional information to
+identify the property as an option and other behaviors. Without the constrained attribute
+this attribute and property it is attached to is ignored by source generation.
+
+``` C#
+using System.IO;
+
+using Ubiquity.NET.CommandLine.GeneratorAttributes;
+
+namespace TestNamespace;
+
+[RootCommand( Description = "Root command for tests" )]
+internal class testInput1
+{
+    // This attribute triggers UNC002 - Property attribute FolderValidation is not allowed on a property independent of a qualifying attribute such as OptionAttribute.
+    [FolderValidation( FolderValidation.CreateIfNotExist )]
+    public required DirectoryInfo SomePath { get; init; }
+}
+```
+
+## Fix
+``` C#
+using System.IO;
+
+using Ubiquity.NET.CommandLine.GeneratorAttributes;
+
+namespace TestNamespace;
+
+[RootCommand( Description = "Root command for tests" )]
+internal class testInput1
+{
+    // Fix is to apply the attribute that indicates the property being validated
+    [Option( "-o", Description = "Test SomePath" )]
+    [FolderValidation( FolderValidation.CreateIfNotExist )]
+    public required DirectoryInfo SomePath { get; init; }
+}
+```

--- a/docfx/CommandLine/Diagnostics/UNC003.md
+++ b/docfx/CommandLine/Diagnostics/UNC003.md
@@ -1,0 +1,24 @@
+# UNC003: Property has incorrect type for attribute
+The property's type is not consistent with the requirements of the attribute applied to it.
+Some attributes (especially validation annotations) require a particular type for the
+property to generate valid code. When this diagnostic is raised it is an indication that an
+incorrect type is used. If this is ignored or suppressed the property is ignored for code
+generation.
+
+## Example
+``` C#
+using System.IO;
+
+using Ubiquity.NET.CommandLine.GeneratorAttributes;
+
+namespace TestNamespace;
+
+[RootCommand( Description = "Root command for tests" )]
+internal class testInput1
+{
+    [Option( "-o", Description = "Test SomePath" )]
+    // This attribute triggers UNC003 - Property attribute 'FileValidation' requires a property of type 'FileInfo'.
+    [FileValidation( FileValidation.ExistingOnly )]
+    public required string SomePath { get; init; }
+}
+```

--- a/docfx/CommandLine/Diagnostics/UNC004.md
+++ b/docfx/CommandLine/Diagnostics/UNC004.md
@@ -1,0 +1,26 @@
+# UNC004 : Property type is nullable but marked as required.
+This diagnostic is reported when a nullable type is marked as `Required`. This usually
+indicates an error in the source applying the attributes. An explicitly annotated nullable
+type has a legit value of null, therefore marking it as `Required` makes no sense. Required
+means that it is validated as specified on the command line, this validation only occurs at
+the time of ***invoking*** the command. (If a different command is parsed from the command
+line arguments then no validation occurs).
+
+
+## Example
+``` C#
+using Ubiquity.NET.CommandLine.GeneratorAttributes;
+
+namespace TestNamespace;
+
+[RootCommand( Description = "Root command for tests" )]
+internal partial class TestOptions
+{
+    // Use of `Required = true` reports diagnostic; UNC004 : Property type is nullable but marked as required.
+    [Option( "--thing1", Aliases = [ "-t" ], Required = true, Description = "Test Thing1", HelpName = "Help name for thing1" )]
+    public bool? Thing1 { get; init; }
+
+    [Option( "--thing2", Aliases = [ "-t" ], Description = "Test Thing2", HelpName = "Help name for thing2" )]
+    public bool Thing2 { get; init; }
+}
+```

--- a/docfx/CommandLine/index.md
+++ b/docfx/CommandLine/index.md
@@ -1,3 +1,16 @@
 # About
 Ubiquity.NET.CommandLine contains general extensions for .NET. to support command line
-parsing using `System.CommandLine`
+parsing using `System.CommandLine`.
+
+A source generator is included that will generate the boilerplate code for command line
+parsing and binding. Additionally an analyzer is provided to aid in identifying problems
+with usage of the attributes for generation.
+
+## Analyzer Diagnostics
+Rule ID | Title |
+--------|-------|
+[UNC000](https://ubiquitydotnet.github.io/Ubiquity.NET.Utils/CommandLine/diagnostics/UNC000.html) | An internal analyzer exception occurred. |
+[UNC001](https://ubiquitydotnet.github.io/Ubiquity.NET.Utils/CommandLine/diagnostics/UNC001.html) | Missing command attribute on containing type. |
+[UNC002](https://ubiquitydotnet.github.io/Ubiquity.NET.Utils/CommandLine/diagnostics/UNC002.html) | Property attribute not allowed standalone. |
+[UNC003](https://ubiquitydotnet.github.io/Ubiquity.NET.Utils/CommandLine/diagnostics/UNC003.html) | Property has incorrect type for attribute. |
+[UNC004](https://ubiquitydotnet.github.io/Ubiquity.NET.Utils/CommandLine/diagnostics/UNC004.html) | Property type is nullable but marked as required. |

--- a/docfx/IgnoredWords.dic
+++ b/docfx/IgnoredWords.dic
@@ -1,0 +1,1 @@
+nullable

--- a/docfx/documentation.msbuildproj
+++ b/docfx/documentation.msbuildproj
@@ -74,6 +74,7 @@
   <Target Name="AlwaysRun" BeforeTargets="AfterBuild">
     <Message Importance="High" Text="NOTE: Building $(MSBuildProjectFile) does NOTHING, docs are built using the docfx tool. This project is simply a convenient placeholder for organizing/editing files" />
   </Target>
+
   <!--
   Target to generate the versioning JSON file for consumption by the docs scripts. This target is explicitly called out
   by the build scripts to generate the JSON file with all the version details from Ubiquity.NET.Versioning.Build.Tasks.

--- a/src/Ubiquity.NET.CodeAnalysis.Utils/TypeSymbolExtensions.cs
+++ b/src/Ubiquity.NET.CodeAnalysis.Utils/TypeSymbolExtensions.cs
@@ -9,7 +9,7 @@ namespace Ubiquity.NET.CodeAnalysis.Utils
         /// <summary>Gets the full name of the symbol (Including namespace names)</summary>
         /// <param name="self">Symbol to get the name from</param>
         /// <returns>Enumerable collection of the name parts with outer most namespace first</returns>
-        public static IEnumerable<string> GetFullName( this ITypeSymbol self )
+        public static IEnumerable<string> GetFullNameParts( this ITypeSymbol self )
         {
             foreach(string namespacePart in GetNamespaceNames( self ))
             {
@@ -17,6 +17,14 @@ namespace Ubiquity.NET.CodeAnalysis.Utils
             }
 
             yield return self.Name;
+        }
+
+        /// <summary>Gets the fill name (including namespaces) of a <see cref="ITypeSymbol"/></summary>
+        /// <param name="self"><see cref="ITypeSymbol"/> to get the name from</param>
+        /// <returns>full name for the type</returns>
+        public static string GetFullName(this ITypeSymbol self)
+        {
+            return string.Join(".", GetFullNameParts(self));
         }
 
         /// <summary>Gets the sequence of namespaces names of the symbol (outermost to innermost)</summary>

--- a/src/Ubiquity.NET.CommandLine.SrcGen.UT/TestFiles/CommandAnalyzerTests/FileValidation_attribute_without_command_triggers_diagnostic/input.cs
+++ b/src/Ubiquity.NET.CommandLine.SrcGen.UT/TestFiles/CommandAnalyzerTests/FileValidation_attribute_without_command_triggers_diagnostic/input.cs
@@ -6,7 +6,7 @@ namespace TestNamespace;
 
 internal class testInput1
 {
-    // This attribute alone should trigger UNC002 - Property attribute FileValidation is not allowed on a property independent of a qualifying attribute such as OptionAttribute.
-    [FileValidation( FileValidation.ExistingOnly )]
+    [Option( "-o", Description = "Test SomePath" )]
+    [FileValidation( FileValidation.ExistingOnly )] // UNC002 : Property attribute not allowed standalone
     public required FileInfo SomePath { get; init; }
 }

--- a/src/Ubiquity.NET.CommandLine.SrcGen.UT/TestFiles/CommandAnalyzerTests/FileValidation_with_wrong_type_produces_UNC002/input.cs
+++ b/src/Ubiquity.NET.CommandLine.SrcGen.UT/TestFiles/CommandAnalyzerTests/FileValidation_with_wrong_type_produces_UNC002/input.cs
@@ -1,0 +1,11 @@
+﻿using Ubiquity.NET.CommandLine.GeneratorAttributes;
+
+namespace TestNamespace;
+
+[RootCommand( Description = "Root command for tests" )]
+internal class testInput1
+{
+    [Option( "-o", Description = "Test SomePath" )]
+    [FileValidation( FileValidation.ExistingOnly )] // UNC003 - Property attribute 'FileValidation' requires a property of type 'FileInfo'.
+    public required string SomePath { get; init; }
+}

--- a/src/Ubiquity.NET.CommandLine.SrcGen.UT/TestFiles/CommandAnalyzerTests/FolderValidation_attribute_without_command_triggers_diagnostic/input.cs
+++ b/src/Ubiquity.NET.CommandLine.SrcGen.UT/TestFiles/CommandAnalyzerTests/FolderValidation_attribute_without_command_triggers_diagnostic/input.cs
@@ -6,7 +6,8 @@ namespace TestNamespace;
 
 internal class testInput1
 {
-    // This attribute alone should trigger UNC002 - Property attribute FileValidation is not allowed on a property independent of a qualifying attribute such as OptionAttribute.
-    [FileValidation( FileValidation.ExistingOnly )]
-    public required FileInfo SomePath { get; init; }
+    // UNC001 - Property attribute 'FolderValidation' is only allowed on a property in a type attributed with a command attribute. This use will be ignored by the generator.
+    // UNC002 - Property attribute 'FolderValidationAttribute' is not allowed on a property independent of a qualifying attribute such as OptionAttribute.
+    [FolderValidation( FolderValidation.ExistingOnly )]
+    public required DirectoryInfo SomePath { get; init; }
 }

--- a/src/Ubiquity.NET.CommandLine.SrcGen.UT/TestFiles/CommandAnalyzerTests/Required_nullable_types_produce_diagnostic/input.cs
+++ b/src/Ubiquity.NET.CommandLine.SrcGen.UT/TestFiles/CommandAnalyzerTests/Required_nullable_types_produce_diagnostic/input.cs
@@ -1,0 +1,14 @@
+﻿using Ubiquity.NET.CommandLine.GeneratorAttributes;
+
+namespace TestNamespace;
+
+[RootCommand( Description = "Root command for tests" )]
+internal partial class TestOptions
+{
+    // Warning : UNC004 : Type 'bool?' for property 'Thing1' is nullable but marked as required; These annotations conflict resulting in behavior that is explicitly UNDEFINED.
+    [Option( "--thing1", Aliases = [ "-t" ], Required = true, Description = "Test Thing1", HelpName = "Help name for thing1" )]
+    public bool? Thing1 { get; init; }
+
+    [Option( "--thing2", Aliases = [ "-t" ], Description = "Test Thing2", HelpName = "Help name for thing2" )]
+    public bool Thing2 { get; init; }
+}

--- a/src/Ubiquity.NET.CommandLine.SrcGen.UT/Ubiquity.NET.CommandLine.SrcGen.UT.csproj
+++ b/src/Ubiquity.NET.CommandLine.SrcGen.UT/Ubiquity.NET.CommandLine.SrcGen.UT.csproj
@@ -29,23 +29,27 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Remove="TestFiles\CommandAnalyzerTests\FileValidation_with_wrong_type_produces_UNC002\input.cs" />
     <Compile Remove="TestFiles\CommandAnalyzerTests\FolderValidation_attribute_without_command_triggers_diagnostic\input.cs" />
     <Compile Remove="TestFiles\CommandAnalyzerTests\FileValidation_attribute_without_command_triggers_diagnostic\input.cs" />
     <Compile Remove="TestFiles\CommandAnalyzerTests\GoldenPath_produces_no_diagnostics\input.cs" />
     <Compile Remove="TestFiles\CommandAnalyzerTests\Option_attribute_without_command_triggers_diagnostic\input.cs" />
     <Compile Remove="TestFiles\RootCommandAttributeTests\Basic_golden_path_succeeds\expected.cs" />
     <Compile Remove="TestFiles\RootCommandAttributeTests\Basic_golden_path_succeeds\Input.cs" />
+    <Compile Remove="TestFiles\CommandAnalyzerTests\Required_nullable_types_produce_diagnostic\input.cs" />
     <Compile Remove="TestFiles\RootCommandAttributeTests\Generator_handles_nullable_types\expected.cs" />
     <Compile Remove="TestFiles\RootCommandAttributeTests\Generator_handles_nullable_types\input.cs" />
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Include="TestFiles\CommandAnalyzerTests\FileValidation_with_wrong_type_produces_UNC002\input.cs" />
     <EmbeddedResource Include="TestFiles\CommandAnalyzerTests\FolderValidation_attribute_without_command_triggers_diagnostic\input.cs" />
     <EmbeddedResource Include="TestFiles\CommandAnalyzerTests\FileValidation_attribute_without_command_triggers_diagnostic\input.cs" />
     <EmbeddedResource Include="TestFiles\CommandAnalyzerTests\GoldenPath_produces_no_diagnostics\input.cs" />
     <EmbeddedResource Include="TestFiles\CommandAnalyzerTests\Option_attribute_without_command_triggers_diagnostic\input.cs" />
     <EmbeddedResource Include="TestFiles\RootCommandAttributeTests\Basic_golden_path_succeeds\expected.cs" />
     <EmbeddedResource Include="TestFiles\RootCommandAttributeTests\Basic_golden_path_succeeds\input.cs" />
+    <EmbeddedResource Include="TestFiles\CommandAnalyzerTests\Required_nullable_types_produce_diagnostic\input.cs" />
     <EmbeddedResource Include="TestFiles\RootCommandAttributeTests\Generator_handles_nullable_types\expected.cs" />
     <EmbeddedResource Include="TestFiles\RootCommandAttributeTests\Generator_handles_nullable_types\input.cs" />
   </ItemGroup>

--- a/src/Ubiquity.NET.CommandLine.SrcGen/AnalyzerReleases.Unshipped.md
+++ b/src/Ubiquity.NET.CommandLine.SrcGen/AnalyzerReleases.Unshipped.md
@@ -6,6 +6,7 @@
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 UNC000 | Internal | Error | Diagnostics, [Documentation](NotConfigurable)
-UNC001 | Usage | Warning | Diagnostics, [Documentation](Unnecessary)
+UNC001 | Usage | Error | Diagnostics
 UNC002 | Usage | Error | Diagnostics, [Documentation](NotConfigurable)
 UNC003 | Usage | Error | Diagnostics, [Documentation](NotConfigurable)
+UNC004 | Usage | Warning | Diagnostics, [Documentation](Compiler)

--- a/src/Ubiquity.NET.CommandLine.SrcGen/Diagnostics.cs
+++ b/src/Ubiquity.NET.CommandLine.SrcGen/Diagnostics.cs
@@ -15,6 +15,7 @@ namespace Ubiquity.NET.CommandLine.SrcGen
             internal const string MissingCommandAttribute = "UNC001";
             internal const string MissingConstraintAttribute = "UNC002";
             internal const string IncorrectPropertyType = "UNC003";
+            internal const string RequiredNullableType = "UNC004";
         }
 
         private static LocalizableResourceString Localized( string resName )
@@ -27,7 +28,8 @@ namespace Ubiquity.NET.CommandLine.SrcGen
                 InternalError,
                 MissingCommandAttribute,
                 MissingConstraintAttribute,
-                IncorrectPropertyType
+                IncorrectPropertyType,
+                RequiredNullableType,
             ];
 
         internal static readonly DiagnosticDescriptor InternalError = new(
@@ -38,6 +40,7 @@ namespace Ubiquity.NET.CommandLine.SrcGen
             defaultSeverity: DiagnosticSeverity.Error,
             isEnabledByDefault: true,
             description: Localized(nameof(Resources.InternalError_Description)),
+            helpLinkUri: FormatHelpUri(IDs.InternalError),
             WellKnownDiagnosticTags.NotConfigurable
             );
 
@@ -46,9 +49,10 @@ namespace Ubiquity.NET.CommandLine.SrcGen
             title: Localized(nameof(Resources.MissingCommandAttribute_Title)),
             messageFormat: Localized(nameof(Resources.MissingCommandAttribute_MessageFormat)),
             category: "Usage",
-            defaultSeverity: DiagnosticSeverity.Warning,
+            defaultSeverity: DiagnosticSeverity.Error,
             isEnabledByDefault: true,
             description: Localized(nameof(Resources.MissingCommandAttribute_Description)),
+            helpLinkUri: FormatHelpUri(IDs.MissingCommandAttribute),
             WellKnownDiagnosticTags.Unnecessary,
             WellKnownDiagnosticTags.Compiler
             );
@@ -61,6 +65,7 @@ namespace Ubiquity.NET.CommandLine.SrcGen
             defaultSeverity: DiagnosticSeverity.Error,
             isEnabledByDefault: true,
             description: Localized(nameof(Resources.MissingConstraintAttribute_Description)),
+            helpLinkUri: FormatHelpUri(IDs.MissingConstraintAttribute),
             WellKnownDiagnosticTags.Compiler
             );
 
@@ -72,8 +77,27 @@ namespace Ubiquity.NET.CommandLine.SrcGen
             defaultSeverity: DiagnosticSeverity.Error,
             isEnabledByDefault: true,
             description: Localized(nameof(Resources.IncorrectPropertyType_Description)),
+            helpLinkUri: FormatHelpUri(IDs.IncorrectPropertyType),
             WellKnownDiagnosticTags.Compiler,
             WellKnownDiagnosticTags.NotConfigurable
             );
+
+        // Type '{0}' for property '{1}' is nullable but marked as required; These annotations conflict resulting in behavior that is explicitly UNDEFINED.
+        internal static readonly DiagnosticDescriptor RequiredNullableType = new(
+            id: IDs.RequiredNullableType,
+            title: Localized(nameof(Resources.RequiredNullableType_Title)),
+            messageFormat: Localized(nameof(Resources.RequiredNullableType_MessageFormat)),
+            category: "Usage",
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: Localized(nameof(Resources.RequiredNullableType_Description)),
+            helpLinkUri: FormatHelpUri(IDs.RequiredNullableType),
+            WellKnownDiagnosticTags.Compiler
+            );
+
+        private static string FormatHelpUri(string id)
+        {
+            return $"https://ubiquitydotnet.github.io/Ubiquity.NET.Utils/CommandLine/diagnostics/{id}.html";
+        }
     }
 }

--- a/src/Ubiquity.NET.CommandLine.SrcGen/Properties/Resources.Designer.cs
+++ b/src/Ubiquity.NET.CommandLine.SrcGen/Properties/Resources.Designer.cs
@@ -167,5 +167,32 @@ namespace Ubiquity.NET.CommandLine.SrcGen.Properties {
                 return ResourceManager.GetString("MissingConstraintAttribute_Title", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Property type is nullable but marked as required; These annotations conflict resulting in behavior that is explicitly UNDEFINED..
+        /// </summary>
+        internal static string RequiredNullableType_Description {
+            get {
+                return ResourceManager.GetString("RequiredNullableType_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to attrib.NamedArguments.
+        /// </summary>
+        internal static string RequiredNullableType_MessageFormat {
+            get {
+                return ResourceManager.GetString("RequiredNullableType_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Property type is nullable but marked as required..
+        /// </summary>
+        internal static string RequiredNullableType_Title {
+            get {
+                return ResourceManager.GetString("RequiredNullableType_Title", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Ubiquity.NET.CommandLine.SrcGen/Properties/Resources.resx
+++ b/src/Ubiquity.NET.CommandLine.SrcGen/Properties/Resources.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -153,5 +153,14 @@
   </data>
   <data name="IncorrectPropertyType_Title" xml:space="preserve">
     <value>Property has incorrect type for attribute</value>
+  </data>
+  <data name="RequiredNullableType_Description" xml:space="preserve">
+    <value>Property type is nullable but marked as required; These annotations conflict resulting in behavior that is explicitly UNDEFINED.</value>
+  </data>
+  <data name="RequiredNullableType_MessageFormat" xml:space="preserve">
+    <value>Type '{0}' for property '{1}' is nullable but marked as required; These annotations conflict resulting in behavior that is explicitly UNDEFINED.</value>
+  </data>
+  <data name="RequiredNullableType_Title" xml:space="preserve">
+    <value>Property type is nullable but marked as required.</value>
   </data>
 </root>


### PR DESCRIPTION
Added test for properties with a nullable type that are marked as required.
* This is, at best, a pointless NOP.
    - Behavior of this is formally UNDEFINED.
    - Generate a warning diagnostic to verify that
* Added documentation for analyzer diagnostics
    - This is published with the documentation for the library
    - Published location is the HelpURI for the diagnostic to allow click through to the helps from an IDE.